### PR TITLE
Prevent excessive getSharedcount work when global $post is null

### DIFF
--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -140,6 +140,11 @@ function mashsbGetShareMethod($mashsbSharesObj) {
 
 function getSharedcount($url) {
     global $wpdb, $mashsb_options, $post;
+    
+    if (is_null($post)) {
+    	return apply_filters('filter_get_sharedcount', 0);
+    }
+    
     isset($mashsb_options['mashsharer_cache']) ? $cacheexpire = $mashsb_options['mashsharer_cache'] : $cacheexpire = 300;
     /* make sure 300sec is default value */
     $cacheexpire < 300 ? $cacheexpire = 300 : $cacheexpire;


### PR DESCRIPTION
Hey Mashshare team,

I noticed (using blackfire.io) on the search page of our site that alot if network requests were made.

It looks like that when the global $post is null the template function getSharedcount tries to retrieve data on every call instead of waiting for the cache to expire, this should not be the case.

This is a possible solution.